### PR TITLE
Identity is diachronic

### DIFF
--- a/content/notes/Identity is diachronic.md
+++ b/content/notes/Identity is diachronic.md
@@ -14,6 +14,6 @@ In philosophy and many other cognitive sciences, this is called an *identity*. A
 
 At Plastic, we think context management/engineering is really better framed as identity management/engineering. Delivering the best context to your system in each moment itself requires a system to understand multiple identities at multiple points in time.
 
-Our system for that is [Honcho](https://honcho.dev), where developers or agents can create a [[Beyond the User-Assistant Paradigm; Introducing Peers|`peer`]] for any identity it's important to model, so that optimal context is synthesized and available when an application needs it. Peers in Honcho are self-improving representations of identity, made of context and the reasoning done by our [Neuromancer](https://honcho.dev/neuromancer) series of models over that context.
+Our system for that is [Honcho](https://honcho.dev), where developers or agents can create a [[Beyond the User-Assistant Paradigm; Introducing Peers|peer]] for any identity it's important to model, so that optimal context is synthesized and available when an application needs it. Peers in Honcho are self-improving representations of identity, made of context and the reasoning done by our [Neuromancer](https://honcho.dev/neuromancer) series of models over that context.
 
 [^1]: Identity over time is a hotly debated topic in philosophy. Those interested should explore the endurantist vs. perdurantist debate and synchronic vs. diachronic identity, especially the work of Parfit & Lewis, from which we take heavy inspiration.

--- a/content/notes/Identity is diachronic.md
+++ b/content/notes/Identity is diachronic.md
@@ -6,11 +6,11 @@ tags:
   - ml
 date: 09.18.25
 ---
-The quality of any single AI system output is in large part determined by the context available to it at inference time. While some context is static and reusable, AI systems aspiring to be truly generative, 1-to-1, and dynamic must also manage large sets of changing context.
+The quality of any single AI system output is in large part determined by the context available to it at inference time. While some context is static and reusable, AI systems aspiring to be truly generative, 1-to-1, and dynamic, must also manage large sets of changing context.
 
 So a major obstacle to solving context management for AI systems is in squaring continuity with change. That is, how do we differentiate between static and evolving context? Or should we instead view both as properties of context sets? What do we even call a body of context that remains static in some ways, but changes over time in others?
 
-In philosophy and many other cognitive sciences this is called an *identity*. All material or conceptual objects have a personal identity--humans, agents, APIs, NPCs, organizations, communities, memes, brands, etc. And those identities have a temporal dimension, they can be coherently understood as enduring things but also as different at different moments in time. They're diachronic[^1].
+In philosophy and many other cognitive sciences, this is called an *identity*. All material or conceptual objects have a personal identity--humans, agents, APIs, NPCs, organizations, communities, memes, brands, etc. And those identities have a temporal dimension; they can be coherently understood as enduring things, but also as different at different moments in time. They're diachronic[^1].
 
 At Plastic, we think context management/engineering is really better framed as identity management/engineering. Delivering the best context to your system in each moment itself requires a system to understand multiple identities at multiple points in time.
 

--- a/content/notes/Identity is diachronic.md
+++ b/content/notes/Identity is diachronic.md
@@ -14,6 +14,6 @@ In philosophy and many other cognitive sciences this is called an *identity*. Al
 
 At Plastic, we think context management/engineering is really better framed as identity management/engineering. Delivering the best context to your system in each moment itself requires a system to understand multiple identities at multiple points in time.
 
-Our system for that is [Honcho](https://honcho.dev), where developers or agents can create [[Beyond the User-Assistant Paradigm; Introducing Peers|`peers`]] for any identity it's important to model, so that optimal context is synthesized and available when an application needs it. Peers in Honcho are self-improving representations of identity, made of context and the reasoning done by our [Neuromancer](https://honcho.dev/neuromancer) series of models over that context.
+Our system for that is [Honcho](https://honcho.dev), where developers or agents can create a [[Beyond the User-Assistant Paradigm; Introducing Peers|`peer`]] for any identity it's important to model, so that optimal context is synthesized and available when an application needs it. Peers in Honcho are self-improving representations of identity, made of context and the reasoning done by our [Neuromancer](https://honcho.dev/neuromancer) series of models over that context.
 
 [^1]: Identity over time is a hotly debated topic in philosophy. Those interested should explore the endurantist vs. perdurantist debate and synchronic vs. diachronic identity, especially the work of Parfit & Lewis, from which we take heavy inspiration.

--- a/content/notes/Identity is diachronic.md
+++ b/content/notes/Identity is diachronic.md
@@ -1,0 +1,19 @@
+---
+title: Identity is diachronic
+tags:
+  - philosophy
+  - honcho
+  - ml
+date: 09.18.25
+---
+The quality of any single AI system output is in large part determined by the context available to it at inference time. While some context is static and reusable, AI systems aspiring to be truly generative, 1-to-1, and dynamic must also manage large sets of changing context.
+
+So a major obstacle to solving context management for AI systems is in squaring continuity with change. That is, how do we differentiate between static and evolving context? Or should we instead view both as properties of context sets? What do we even call a body of context that remains static in some ways, but changes over time in others?
+
+In philosophy and many other cognitive sciences this is called an *identity*. All material or conceptual objects have a personal identity--humans, agents, APIs, NPCs, organizations, communities, memes, brands, etc. And those identities have a temporal dimension, they can be coherently understood as enduring things but also as different at different moments in time. They're diachronic[^1].
+
+At Plastic, we think context management/engineering is really better framed as identity management/engineering. Delivering the best context to your system in each moment itself requires a system to understand multiple identities at multiple points in time.
+
+Our system for that is [Honcho](https://honcho.dev), where developers or agents can create [[Beyond the User-Assistant Paradigm; Introducing Peers|`peers`]] for any identity it's important to model, so that optimal context is synthesized and available when an application needs it. Peers in Honcho are self-improving representations of identity, made of context and the reasoning done by our [Neuromancer](https://honcho.dev/neuromancer) series of models over that context.
+
+[^1]: Identity over time is a hotly debated topic in philosophy. Those interested should explore the endurantist vs. perdurantist debate and synchronic vs. diachronic identity, especially the work of Parfit & Lewis, from which we take heavy inspiration.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new note “Identity is diachronic” (tags: philosophy, honcho, ml; dated 2025-09-18).
  * Explores how AI output depends on inference-time context, contrasting static vs. evolving context and framing it as identity management over time.
  * Proposes modeling multiple self-improving identities (“peers”) to provide optimal context; references Honcho, Neuromancer, and related peers note; includes a footnote on diachronic identity debates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->